### PR TITLE
Promote develop: streaming geoip import (fix city_block OOM) + actuator metrics + env-prefixed CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,18 +17,24 @@ jobs:
       - name: Compute tags
         id: tags
         run: |
-          # Immutable tag — Argo CD Image Updater watches `sha-<short>` and bumps
-          # the manifest. Mutable tag kept for transition / manual rollbacks.
+          # Env-prefixed immutable tag — Argo CD Image Updater watches
+          # `<env>-sha-<short>` per overlay. Prefix MUST match the kustomize
+          # overlay directory name (development / production) so the regex
+          # `^{{path.basename}}-sha-…` in bootstrap/registrations/apps.yaml
+          # picks the right tag per environment. Mutable tag kept for
+          # transition / manual rollbacks; drop once everything's switched.
           SHORT_SHA=${GITHUB_SHA::7}
           if [ "${{ github.ref_name }}" == "main" ]; then
+            ENV_NAME=production
             MUTABLE=prod
           elif [ "${{ github.ref_name }}" == "develop" ]; then
+            ENV_NAME=development
             MUTABLE=latest
           else
             echo "Unsupported branch: ${{ github.ref_name }}"
             exit 1
           fi
-          echo "SHA_TAG=sha-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "SHA_TAG=${ENV_NAME}-sha-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
           echo "MUTABLE_TAG=${MUTABLE}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to Harbor registry

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,17 +14,22 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
 
-      - name: Set Docker image tag based on branch
-        id: set-tag
+      - name: Compute tags
+        id: tags
         run: |
+          # Immutable tag — Argo CD Image Updater watches `sha-<short>` and bumps
+          # the manifest. Mutable tag kept for transition / manual rollbacks.
+          SHORT_SHA=${GITHUB_SHA::7}
           if [ "${{ github.ref_name }}" == "main" ]; then
-            echo "TAG=prod" >> $GITHUB_OUTPUT
+            MUTABLE=prod
           elif [ "${{ github.ref_name }}" == "develop" ]; then
-            echo "TAG=latest" >> $GITHUB_OUTPUT
+            MUTABLE=latest
           else
             echo "Unsupported branch: ${{ github.ref_name }}"
             exit 1
           fi
+          echo "SHA_TAG=sha-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "MUTABLE_TAG=${MUTABLE}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to Harbor registry
         uses: docker/login-action@v3
@@ -35,8 +40,14 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build -t ${{ secrets.HARBOR_REGISTRY }}/paradaux-public/paradaux-api:${{ steps.set-tag.outputs.TAG }} .
+          IMAGE=${{ secrets.HARBOR_REGISTRY }}/paradaux-public/paradaux-api
+          docker build \
+            -t "${IMAGE}:${{ steps.tags.outputs.SHA_TAG }}" \
+            -t "${IMAGE}:${{ steps.tags.outputs.MUTABLE_TAG }}" \
+            .
 
       - name: Push Docker image
         run: |
-          docker push ${{ secrets.HARBOR_REGISTRY }}/paradaux-public/paradaux-api:${{ steps.set-tag.outputs.TAG }}
+          IMAGE=${{ secrets.HARBOR_REGISTRY }}/paradaux-public/paradaux-api
+          docker push "${IMAGE}:${{ steps.tags.outputs.SHA_TAG }}"
+          docker push "${IMAGE}:${{ steps.tags.outputs.MUTABLE_TAG }}"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,10 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web:3.5.3")
     implementation("org.springframework.boot:spring-boot-starter-webflux:3.5.3")
 
+    // Observability — actuator health/info/prometheus on a separate management port
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("io.micrometer:micrometer-registry-prometheus")
+
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
     implementation("org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")

--- a/src/main/java/io/paradaux/api/jobs/MaxMindSyncJob.java
+++ b/src/main/java/io/paradaux/api/jobs/MaxMindSyncJob.java
@@ -8,7 +8,6 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
 import java.util.HashMap;
 
 @Service
@@ -31,9 +30,12 @@ public class MaxMindSyncJob {
 
         try {
             geoIPInformationService.importAllData();
-        } catch (IOException e) {
+        } catch (Exception e) {
+            // Catch Exception (not just IOException) — mybatis surfaces DB failures as
+            // unchecked exceptions, and those must still alert + abort, not be lost.
             log.error("Failed to import MaxMind GeoIP data", e);
-            discordService.sendMessage("MaxMind GeoIP data synchronization failure", e.getMessage(), new HashMap<>());
+            discordService.sendMessage("MaxMind GeoIP data synchronization failure",
+                    String.valueOf(e.getMessage()), new HashMap<>());
             return;
         }
 

--- a/src/main/java/io/paradaux/api/services/GeoIPInformationService.java
+++ b/src/main/java/io/paradaux/api/services/GeoIPInformationService.java
@@ -10,7 +10,7 @@ import java.util.Map;
 public interface GeoIPInformationService {
 
     void importAllData() throws IOException;
-    void importAllData(Path dataDir);
+    void importAllData(Path dataDir) throws IOException;
     Map<String, Object> getIPDetails(String ipAddress);
     CityBlock getCityBlock(String ipAddress);
     Map<String, Object> getASNDetails(String ipAddress);

--- a/src/main/java/io/paradaux/api/services/impl/GeoIPInformationServiceImpl.java
+++ b/src/main/java/io/paradaux/api/services/impl/GeoIPInformationServiceImpl.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.util.FileSystemUtils;
 
 import java.io.FileReader;
 import java.io.IOException;
@@ -20,16 +21,24 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
+import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class GeoIPInformationServiceImpl implements GeoIPInformationService {
 
+    /**
+     * Rows per multi-row INSERT. Kept conservative so (BATCH_SIZE * widest table's
+     * column count) stays well under Postgres' 65535 bind-parameter limit
+     * (location is the widest at 14 cols -> 14k params). Rows are flushed in
+     * batches AS the CSV is streamed, so heap stays flat regardless of file size.
+     */
     private static final int BATCH_SIZE = 1000;
 
     private final GeoIPMapper geoIPMapper;
@@ -41,6 +50,8 @@ public class GeoIPInformationServiceImpl implements GeoIPInformationService {
     private String maxMindUserId;
 
     private static final String MAXMIND_DOWNLOAD_URL = "https://download.maxmind.com/geoip/databases/GeoLite2-%s-CSV/download?suffix=zip";
+
+    // ── Lookups ────────────────────────────────────────────────────────────────
 
     @Override
     public Map<String, Object> lookupIP(String ipAddress) {
@@ -76,77 +87,39 @@ public class GeoIPInformationServiceImpl implements GeoIPInformationService {
         return geoIPMapper.getLocationById(geonameId);
     }
 
+    // ── Import ──────────────────────────────────────────────────────────────────
+
     public void importAllData() throws IOException {
-        // Download zips from MaxMind
         Path dataDir = downloadAllData();
-
-        // Process and import data from MaxMind
-        importAllData(dataDir);
-    }
-
-    public void importAllData(Path dataDir) {
-        geoIPMapper.truncateAll();
-
         try {
-            // Import locations first - use Path instead of String
-            importLocations(dataDir.resolve("city/GeoLite2-City-Locations-en.csv"));
-
-            // Import ASNs and ASN blocks in parallel with city blocks
-            CompletableFuture<Void> asnFuture = CompletableFuture.runAsync(() -> {
-                try {
-                    importASNsAndBlocks(
-                            dataDir.resolve("asn/GeoLite2-ASN-Blocks-IPv4.csv"),
-                            dataDir.resolve("asn/GeoLite2-ASN-Blocks-IPv6.csv")
-                    );
-                } catch (Exception e) {
-                    log.error("Failed to import ASN data", e);
-                }
-            });
-
-            CompletableFuture<Void> cityFuture = CompletableFuture.runAsync(() -> {
-                try {
-                    importCityBlocks(
-                            dataDir.resolve("city/GeoLite2-City-Blocks-IPv4.csv"),
-                            dataDir.resolve("city/GeoLite2-City-Blocks-IPv6.csv")
-                    );
-                } catch (Exception e) {
-                    log.error("Failed to import city blocks", e);
-                }
-            });
-
-            // Wait for both to complete
-            CompletableFuture.allOf(asnFuture, cityFuture).join();
-            log.info("All GeoIP data imported successfully from: {}", dataDir);
-
-        } catch (Exception e) {
-            log.error("Failed to import GeoIP data from: {}", dataDir, e);
+            importAllData(dataDir);
+        } finally {
+            // The MaxMind zips/CSVs are hundreds of MB; never leak them into the pod's
+            // ephemeral storage between weekly runs. Don't let cleanup mask a real failure.
+            try {
+                FileSystemUtils.deleteRecursively(dataDir);
+            } catch (IOException e) {
+                log.warn("Failed to clean up temp GeoIP dir {}", dataDir, e);
+            }
         }
     }
 
-    private Path downloadAllData() throws IOException {
-        Path dataDir = Files.createTempDirectory("geoip-");
-        Path cityDir = dataDir.resolve("city");
-        Path asnDir = dataDir.resolve("asn");
+    /**
+     * Full refresh of the geoip schema. Loads in FK order (location before
+     * city_block, autonomous_system before asn_block) and streams each CSV so the
+     * 5.7M-row city-blocks file no longer materialises in heap. Any failure
+     * propagates (the caller alerts + the run is retried) rather than being
+     * swallowed into a misleading "success".
+     */
+    public void importAllData(Path dataDir) throws IOException {
+        log.info("Starting GeoIP import from {}", dataDir);
+        geoIPMapper.truncateAll();
 
-        String url = String.format(MAXMIND_DOWNLOAD_URL, "City");
-        FileUtils.downloadAndExtractZip(url, cityDir, maxMindUserId, maxMindLicenseKey);
-        url = String.format(MAXMIND_DOWNLOAD_URL, "ASN");
-        FileUtils.downloadAndExtractZip(url, asnDir,  maxMindUserId, maxMindLicenseKey);
-        return dataDir;
-    }
-
-    // Update method signatures to accept Path instead of String
-    private void importLocations(Path csvPath) throws IOException, CsvValidationException {
-        List<IPLocation> locations = new ArrayList<>();
-        try (CSVReader reader = new CSVReader(new FileReader(csvPath.toFile()))) {
-            reader.readNext(); // skip header
-            String[] line;
-            while ((line = reader.readNext()) != null) {
-                if (line.length < 14) {
-                    log.warn("Skipping location row with insufficient columns: {}", line.length);
-                    continue;
-                }
-
+        try {
+            // 1) Locations first — city_block.geoname_id FKs to it. Remember which
+            //    geoname_ids actually exist so we can null out dangling refs below.
+            Set<Integer> validGeonames = new HashSet<>();
+            int locations = streamInsert(14, geoIPMapper::insertLocations, line -> {
                 IPLocation loc = new IPLocation();
                 loc.setGeonameId(parseIntOrNull(line[0]));
                 loc.setLocaleCode(parseStringOrNull(line[1]));
@@ -162,110 +135,132 @@ public class GeoIPInformationServiceImpl implements GeoIPInformationService {
                 loc.setMetroCode(parseStringOrNull(line[11]));
                 loc.setTimeZone(parseStringOrNull(line[12]));
                 loc.setIsInEuropeanUnion("1".equals(line[13]));
-                locations.add(loc);
-            }
+                if (loc.getGeonameId() != null) validGeonames.add(loc.getGeonameId());
+                return loc;
+            }, dataDir.resolve("city/GeoLite2-City-Locations-en.csv"));
+
+            // 2) Unique ASNs (small — ~tens of thousands) before asn_block (FK).
+            int asns = importAsns(
+                    dataDir.resolve("asn/GeoLite2-ASN-Blocks-IPv4.csv"),
+                    dataDir.resolve("asn/GeoLite2-ASN-Blocks-IPv6.csv"));
+
+            // 3) ASN blocks (streamed).
+            int asnBlocks = streamInsert(3, geoIPMapper::insertASNBlocks, line -> {
+                String network = parseStringOrNull(line[0]);
+                Integer asnNumber = parseIntOrNull(line[1]);
+                if (network == null || asnNumber == null) return null;
+                ASNBlock block = new ASNBlock();
+                block.setNetwork(network);
+                block.setAutonomousSystemNumber(asnNumber);
+                return block;
+            }, dataDir.resolve("asn/GeoLite2-ASN-Blocks-IPv4.csv"),
+               dataDir.resolve("asn/GeoLite2-ASN-Blocks-IPv6.csv"));
+
+            // 4) City blocks (the big one, ~5.7M) — streamed. Drop a geoname_id that
+            //    isn't in the locations file so a stray ref can't fail a whole batch.
+            int cityBlocks = streamInsert(11, geoIPMapper::insertCityBlocks, line -> {
+                String network = parseStringOrNull(line[0]);
+                if (network == null) return null; // network is the PK
+                CityBlock block = new CityBlock();
+                block.setNetwork(network);
+                Integer geonameId = parseIntOrNull(line[1]);
+                block.setGeonameId(geonameId != null && validGeonames.contains(geonameId) ? geonameId : null);
+                block.setRegisteredCountryGeonameId(parseIntOrNull(line[2]));
+                block.setRepresentedCountryGeonameId(parseIntOrNull(line[3]));
+                block.setIsAnonymousProxy("1".equals(line[4]));
+                block.setIsSatelliteProvider("1".equals(line[5]));
+                block.setPostalCode(parseStringOrNull(line[6]));
+                block.setLatitude(parseDoubleOrNull(line[7]));
+                block.setLongitude(parseDoubleOrNull(line[8]));
+                block.setAccuracyRadius(parseIntOrNull(line[9]));
+                block.setIsAnycast("1".equals(line[10]));
+                return block;
+            }, dataDir.resolve("city/GeoLite2-City-Blocks-IPv4.csv"),
+               dataDir.resolve("city/GeoLite2-City-Blocks-IPv6.csv"));
+
+            log.info("GeoIP import complete: {} locations, {} ASNs, {} ASN blocks, {} city blocks",
+                    locations, asns, asnBlocks, cityBlocks);
+        } catch (CsvValidationException e) {
+            throw new IOException("Failed parsing a GeoIP CSV", e);
         }
-        log.debug("Imported {} locations", locations.size());
-        batchInsert(locations, geoIPMapper::insertLocations);
     }
 
-    private void importASNsAndBlocks(Path... csvPaths) throws IOException, CsvValidationException {
+    /** Collects the unique ASNs across the given files into a small map and inserts them. */
+    private int importAsns(Path... csvPaths) throws IOException, CsvValidationException {
         Map<Integer, ASN> uniqueAsns = new HashMap<>();
-        List<ASNBlock> asnBlocks = new ArrayList<>();
-
         for (Path csvPath : csvPaths) {
             try (CSVReader reader = new CSVReader(new FileReader(csvPath.toFile()))) {
-                reader.readNext(); // skip header
+                reader.readNext(); // header
                 String[] line;
                 while ((line = reader.readNext()) != null) {
-                    if (line.length < 3) {
-                        log.warn("Skipping ASN row with insufficient columns: {}", line.length);
-                        continue;
-                    }
-
-                    String network = parseStringOrNull(line[0]);
+                    if (line.length < 3) continue;
                     Integer asnNumber = parseIntOrNull(line[1]);
-                    String asnOrg = parseStringOrNull(line[2]);
-
-                    if (network == null || asnNumber == null) {
-                        continue;
-                    }
-
-                    // Store unique ASN
-                    if (!uniqueAsns.containsKey(asnNumber)) {
-                        ASN asn = new ASN();
-                        asn.setAutonomousSystemNumber(asnNumber);
-                        asn.setAutonomousSystemOrganization(asnOrg);
-                        uniqueAsns.put(asnNumber, asn);
-                    }
-
-                    // Store ASN block
-                    ASNBlock asnBlock = new ASNBlock();
-                    asnBlock.setNetwork(network);
-                    asnBlock.setAutonomousSystemNumber(asnNumber);
-                    asnBlocks.add(asnBlock);
+                    if (asnNumber == null || uniqueAsns.containsKey(asnNumber)) continue;
+                    ASN asn = new ASN();
+                    asn.setAutonomousSystemNumber(asnNumber);
+                    asn.setAutonomousSystemOrganization(parseStringOrNull(line[2]));
+                    uniqueAsns.put(asnNumber, asn);
                 }
             }
         }
-
-        log.debug("Imported {} unique ASNs and {} ASN blocks", uniqueAsns.size(), asnBlocks.size());
-
-        // Insert ASNs first (due to foreign key constraint)
-        batchInsert(new ArrayList<>(uniqueAsns.values()), geoIPMapper::insertASNs);
-
-        // Then insert ASN blocks
-        batchInsert(asnBlocks, geoIPMapper::insertASNBlocks);
+        insertInBatches(new ArrayList<>(uniqueAsns.values()), geoIPMapper::insertASNs);
+        return uniqueAsns.size();
     }
 
-    private void importCityBlocks(Path... csvPaths) throws IOException, CsvValidationException {
-        List<CityBlock> cityBlocks = new ArrayList<>();
-
+    /**
+     * Streams one or more CSVs, mapping each row and flushing to the DB every
+     * BATCH_SIZE rows so heap usage stays flat. Rows the mapper returns null for
+     * (or that are too short) are skipped. Insert failures propagate.
+     */
+    private <T> int streamInsert(int minColumns, Consumer<List<T>> insert,
+                                 Function<String[], T> mapper, Path... csvPaths)
+            throws IOException, CsvValidationException {
+        int inserted = 0;
+        int skipped = 0;
+        List<T> batch = new ArrayList<>(BATCH_SIZE);
         for (Path csvPath : csvPaths) {
             try (CSVReader reader = new CSVReader(new FileReader(csvPath.toFile()))) {
-                reader.readNext(); // skip header
+                reader.readNext(); // header
                 String[] line;
                 while ((line = reader.readNext()) != null) {
-                    if (line.length < 11) {
-                        log.warn("Skipping city block row with insufficient columns: {}", line.length);
-                        continue;
+                    if (line.length < minColumns) { skipped++; continue; }
+                    T row = mapper.apply(line);
+                    if (row == null) { skipped++; continue; }
+                    batch.add(row);
+                    if (batch.size() >= BATCH_SIZE) {
+                        insert.accept(batch);
+                        inserted += batch.size();
+                        batch.clear();
                     }
-
-                    CityBlock block = new CityBlock();
-                    block.setNetwork(parseStringOrNull(line[0]));
-                    block.setGeonameId(parseIntOrNull(line[1]));
-                    block.setRegisteredCountryGeonameId(parseIntOrNull(line[2]));
-                    block.setRepresentedCountryGeonameId(parseIntOrNull(line[3]));
-                    block.setIsAnonymousProxy("1".equals(line[4]));
-                    block.setIsSatelliteProvider("1".equals(line[5]));
-                    block.setPostalCode(parseStringOrNull(line[6]));
-                    block.setLatitude(parseDoubleOrNull(line[7]));
-                    block.setLongitude(parseDoubleOrNull(line[8]));
-                    block.setAccuracyRadius(parseIntOrNull(line[9]));
-                    block.setIsAnycast("1".equals(line[10]));
-
-                    cityBlocks.add(block);
                 }
             }
         }
-
-        log.debug("Imported {} city blocks", cityBlocks.size());
-        batchInsert(cityBlocks, geoIPMapper::insertCityBlocks);
+        if (!batch.isEmpty()) {
+            insert.accept(batch);
+            inserted += batch.size();
+        }
+        if (skipped > 0) log.warn("Skipped {} malformed/incomplete rows across {} file(s)", skipped, csvPaths.length);
+        return inserted;
     }
 
-    private <T> void batchInsert(List<T> list, Consumer<List<T>> insertFunction) {
+    /** Inserts an in-memory list in BATCH_SIZE chunks (used only for the small ASN set). */
+    private <T> void insertInBatches(List<T> list, Consumer<List<T>> insert) {
         for (int i = 0; i < list.size(); i += BATCH_SIZE) {
-            int end = Math.min(i + BATCH_SIZE, list.size());
-            List<T> batch = list.subList(i, end);
-            try {
-                insertFunction.accept(batch);
-                if (i % (BATCH_SIZE * 10) == 0) {
-                    log.debug("Processed {} records", i + batch.size());
-                }
-            } catch (Exception e) {
-                log.error("Failed to insert batch starting at index {}", i, e);
-            }
+            insert.accept(list.subList(i, Math.min(i + BATCH_SIZE, list.size())));
         }
     }
+
+    private Path downloadAllData() throws IOException {
+        Path dataDir = Files.createTempDirectory("geoip-");
+        Path cityDir = dataDir.resolve("city");
+        Path asnDir = dataDir.resolve("asn");
+
+        FileUtils.downloadAndExtractZip(String.format(MAXMIND_DOWNLOAD_URL, "City"), cityDir, maxMindUserId, maxMindLicenseKey);
+        FileUtils.downloadAndExtractZip(String.format(MAXMIND_DOWNLOAD_URL, "ASN"), asnDir, maxMindUserId, maxMindLicenseKey);
+        return dataDir;
+    }
+
+    // ── Parsing helpers ─────────────────────────────────────────────────────────
 
     private Integer parseIntOrNull(String s) {
         if (s == null || s.trim().isEmpty()) return null;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,3 +30,21 @@ mybatis:
 
 maxmind:
   base-url: https://download.maxmind.com/app/geoip_download
+
+# Actuator on a dedicated management port (8081) so /actuator/prometheus is
+# reachable in-cluster (ServiceMonitor) but never via the public api.paradaux.io
+# route, which only fronts the app port (8080).
+management:
+  server:
+    port: ${MANAGEMENT_PORT:8081}
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}


### PR DESCRIPTION
Promotes develop to main (prod).

- **geoip: stream the MaxMind import** — the city-blocks CSV (5.7M rows) was loaded entirely into heap before inserting, OOMing the JVM (only city_block was big enough), and the failure was swallowed (CompletableFuture caught Exception not Error; per-batch catch ignored failures) so the job mislogged success. Now streams each CSV in 1k-row batches (flat heap), loads in FK order, drops dangling city_block.geoname_id refs, fails loudly, and cleans up the temp files. MaxMindSyncJob catches all failures.
- Prometheus/actuator metrics on the management port (aligns the prod image with the ServiceMonitor already scraping it).
- env-prefixed CI image tags (production-sha-* / development-sha-*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)